### PR TITLE
Fix exp is_extended_positive for maybe -inf

### DIFF
--- a/sympy/functions/elementary/exponential.py
+++ b/sympy/functions/elementary/exponential.py
@@ -473,7 +473,8 @@ class exp(ExpBase, metaclass=ExpMeta):
 
     def _eval_is_extended_positive(self):
         if self.exp.is_extended_real:
-            return self.args[0] is not S.NegativeInfinity
+            if self.args[0].is_real or self.args[0].is_extended_nonnegative:
+                return True
         elif self.exp.is_imaginary:
             arg2 = -I * self.args[0] / pi
             return arg2.is_even


### PR DESCRIPTION

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->

Fixes #28141

CC @oscarbenjamin


#### Brief description of what is fixed or changed

For an extended real expression, I.e. one that can be -inf, exp previously returned is_extended_positive = True if the expression was not literally -inf.

This PR fixes the logic to ensure that expressions where -inf is possible return is_extended_positive = None.

#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->
* functions
  * Fixed a bug with assumptions of the exponential function. exp(x) where x may be -inf will now correctly assume that exp(x) may be zero.
<!-- END RELEASE NOTES -->
